### PR TITLE
using existing_atom checks

### DIFF
--- a/lib/map_based.ex
+++ b/lib/map_based.ex
@@ -3,13 +3,13 @@ defmodule Sortex.MapBased do
   alias Sortex.Order
 
   def sort(query, field_name, direction, assocs) do
-    field = field_to_atom!(field_name, query)
-    field_source = field_source(query, field_name, assocs)
+    field = String.to_existing_atom(field_name)
+    field_source = field_source(query, field, assocs)
     do_sort(field_source, field, query, direction)
   end
 
   defp field_source(query, field_name, _assocs = nil) do
-    case field_name in select_fields_as_strings(query) do
+    case field_name in select_fields!(query) do
       true ->
         :from_base_table
 
@@ -33,34 +33,8 @@ defmodule Sortex.MapBased do
     matching_join_index
   end
 
-  defp field_to_atom!(field_name, query) do
-    fields =
-      query
-      |> select_fields!()
-      |> Keyword.values()
-      |> Enum.reject(fn x -> match?({:fragment, _, _}, x) end)
-      |> Enum.map(fn {{_, _, [_, underlying_field_name]}, _, _} ->
-        Atom.to_string(underlying_field_name)
-      end)
-
-    if field_name in fields do
-      String.to_atom(field_name)
-    else
-      raise ~s|No field on map or joined tables for field: #{field_name} in query: #{
-              inspect(query)
-            }|
-    end
-  end
-
-  defp select_fields!(%{select: %{expr: {_, _, fields}}}), do: fields
+  defp select_fields!(%{select: %{expr: {_, _, fields}}}), do: fields |> Keyword.keys()
   defp select_fields!(query), do: raise("No select clause found in query: #{inspect(query)}")
-
-  defp select_fields_as_strings(query) do
-    query
-    |> select_fields!()
-    |> Keyword.keys()
-    |> Enum.map(&Atom.to_string/1)
-  end
 
   defp do_sort(:from_base_table, field, query, direction) do
     order_by(query, [x], [{^direction, ^field}])

--- a/lib/map_based.ex
+++ b/lib/map_based.ex
@@ -8,17 +8,7 @@ defmodule Sortex.MapBased do
     do_sort(field_source, field, query, direction)
   end
 
-  defp field_source(query, field_name, _assocs = nil) do
-    case field_name in select_fields!(query) do
-      true ->
-        :from_base_table
-
-      false ->
-        raise ~s|field "#{field_name}" does not exist in select fields for query "#{
-                inspect(query)
-              }"|
-    end
-  end
+  defp field_source(_, _, _assocs = nil), do: :from_base_table
 
   defp field_source(query, _, related_table) do
     {:from_join, table_join_index(query, related_table)}
@@ -32,9 +22,6 @@ defmodule Sortex.MapBased do
 
     matching_join_index
   end
-
-  defp select_fields!(%{select: %{expr: {_, _, fields}}}), do: fields |> Keyword.keys()
-  defp select_fields!(query), do: raise("No select clause found in query: #{inspect(query)}")
 
   defp do_sort(:from_base_table, field, query, direction) do
     order_by(query, [x], [{^direction, ^field}])

--- a/lib/schema_based/field.ex
+++ b/lib/schema_based/field.ex
@@ -1,18 +1,14 @@
 defmodule Sortex.SchemaBased.Field do
-  def to_atom_if_present_on_struct!(_, field_name) when is_atom(field_name), do: field_name
-
   def to_atom_if_present_on_struct!(struct, field) do
     case field in struct_fields(struct) do
       true -> struct
       false -> raise ~s|associated field <#{field}> not found on schema <#{struct.__struct__}>|
     end
-
-    String.to_atom(field)
+    field
   end
 
   defp struct_fields(struct) do
     struct
     |> Map.keys()
-    |> Enum.map(&Atom.to_string/1)
   end
 end

--- a/lib/schema_based/relationship_tree.ex
+++ b/lib/schema_based/relationship_tree.ex
@@ -10,7 +10,7 @@ defmodule Sortex.SchemaBased.RelationshipTree do
         [{:root, base_struct, :no_assoc_field}],
         fn assoc_field_name, [{_, parent, _} | _] = acc ->
           assoc_struct = associated_struct!(parent, assoc_field_name)
-          [{parent, assoc_struct, String.to_atom(assoc_field_name)} | acc]
+          [{parent, assoc_struct, assoc_field_name} | acc]
         end
       )
 

--- a/lib/schema_based/schema_based.ex
+++ b/lib/schema_based/schema_based.ex
@@ -6,6 +6,7 @@ defmodule Sortex.SchemaBased do
   @base_table_binding_index 0
 
   def sort(query, sort_field, direction, assocs) do
+    sort_field = String.to_existing_atom(sort_field)
     case assocs do
       nil -> order_by(query, sort_field, direction, [])
       [_ | _] = assocs -> order_by(query, sort_field, direction, assocs)
@@ -14,12 +15,13 @@ defmodule Sortex.SchemaBased do
   end
 
   defp order_by(query, sort_field, direction, assocs) do
+    assocs = Enum.map(assocs, &String.to_existing_atom/1)
     relationship_tree = RelationshipTree.from_parameters!(query, sort_field, assocs)
 
     query = add_joins(query, relationship_tree)
     order_by_binding_index = order_by_binding_index(relationship_tree, query)
 
-    Order.by(query, order_by_binding_index, direction, String.to_atom(sort_field))
+    Order.by(query, order_by_binding_index, direction, sort_field)
   end
 
   defp add_joins(query, relationship_tree) do

--- a/test/schema_based/relationship_tree_test.exs
+++ b/test/schema_based/relationship_tree_test.exs
@@ -6,7 +6,7 @@ defmodule Sortex.SchemaBased.RelationshipTreeTest do
 
   describe "from_parameters!/3" do
     test "returns no_relationships if field is directly on base table" do
-      assert [] == RelationshipTree.from_parameters!(%Animal{}, "number_of_legs", [])
+      assert [] == RelationshipTree.from_parameters!(%Animal{}, :number_of_legs, [])
     end
 
     test "returns tree for valid parameters" do
@@ -14,9 +14,9 @@ defmodule Sortex.SchemaBased.RelationshipTreeTest do
                {Animal, Feed, :feed},
                {Feed, Supplier, :supplier}
              ] ==
-               RelationshipTree.from_parameters!(%Animal{}, "name", [
-                 "feed",
-                 "supplier"
+               RelationshipTree.from_parameters!(%Animal{}, :name, [
+                 :feed,
+                 :supplier
                ])
     end
 
@@ -32,7 +32,7 @@ defmodule Sortex.SchemaBased.RelationshipTreeTest do
     test "raises if field is not present on assoc" do
       error =
         assert_raise(RuntimeError, fn ->
-          RelationshipTree.from_parameters!(%Animal{}, "number_of_biscuits", ["feed"])
+          RelationshipTree.from_parameters!(%Animal{}, :number_of_biscuits, [:feed])
         end)
 
       assert ~s|associated field <number_of_biscuits> not found on schema <#{Feed}>| ==
@@ -41,7 +41,7 @@ defmodule Sortex.SchemaBased.RelationshipTreeTest do
 
     test "raises if given assoc is not present on struct" do
       assert_raise(RuntimeError, fn ->
-        RelationshipTree.from_parameters!(%Animal{}, "dont care", ["number_of_legs"])
+        RelationshipTree.from_parameters!(%Animal{}, :dont_care, [:number_of_legs])
       end)
     end
   end


### PR DESCRIPTION
Making some bits simpler...

we can just use string.to_existing_atom to check if we can cast to an atom, for some reason i didnt know this existed when i wrote this